### PR TITLE
fix: resolve conflicting JSON import methods

### DIFF
--- a/src/Pages/PDFViewer.jsx
+++ b/src/Pages/PDFViewer.jsx
@@ -5,7 +5,7 @@ import { useSearchParams } from "react-router-dom";
 import { Minimize2, Maximize2, FileText } from "lucide-react";
 import { useBookmarks } from "../context/BookmarkContext";
 
-const allJSONFiles = import.meta.glob("/src/JSON/**/*.json");
+const allJSONFiles = import.meta.glob("/src/JSON/**/*.json", { eager: true });
 
 // function Doc({ name, href }) {
 //   return (


### PR DESCRIPTION
 We addressed a minor error in the PDFHOUSE project related to how JSON files were imported.

  Problem:
  The project was generating build warnings because the same JSON data files were being imported in two different ways:
   * src/Pages/SearchPage.jsx was importing them statically (eagerly) at build time.
   * src/Pages/PDFViewer.jsx was importing them dynamically at runtime.

  This inconsistency caused the build tool (Vite) to report warnings about modules being imported both dynamically and statically.

  Solution:
  We modified src/Pages/PDFViewer.jsx to import the JSON files statically (eagerly) as well. This was done by changing the import.meta.glob
  call from:
   1 const allJSONFiles = import.meta.glob("/src/JSON/**/*.json");
  to:
   1 const allJSONFiles = import.meta.glob("/src/JSON/**/*.json", { eager: true });

  Impact:
  This change resolved all the build warnings, ensuring consistent and efficient handling of JSON data imports across the application. The
  build now completes cleanly without any reported issues.